### PR TITLE
Fix mp_maxrounds not being preserved by votescramble

### DIFF
--- a/addons/sourcemod/scripting/nativevotes_mapchooser.sp
+++ b/addons/sourcemod/scripting/nativevotes_mapchooser.sp
@@ -36,6 +36,7 @@
  
 #include <sourcemod>
 #include <mapchooser>
+#include <sdktools>
 #include <nextmap>
 #include <regex>
 
@@ -112,7 +113,6 @@ Menu g_VoteMenu;
 NativeVote g_VoteNative;
 
 int g_Extends;
-int g_TotalRounds;
 bool g_HasVoteStarted;
 bool g_WaitingForVote;
 bool g_MapVoteCompleted;
@@ -209,7 +209,6 @@ public void OnPluginStart()
 			case Engine_TF2:
 			{
 				HookEvent("teamplay_win_panel", Event_TeamplayWinPanel);
-				HookEvent("teamplay_restart_round", Event_TeamplayRestartRound);
 				HookEvent("arena_win_panel", Event_TeamplayWinPanel);
 			}
 			case Engine_NuclearDawn:
@@ -334,9 +333,7 @@ public void OnConfigsExecuted()
 
 	CreateNextVote();
 	SetupTimeleftTimer();
-	
-	g_TotalRounds = 0;
-	
+		
 	g_Extends = 0;
 	
 	g_MapVoteCompleted = false;
@@ -492,12 +489,6 @@ public Action Timer_StartMapVote(Handle timer, DataPack data)
 	return Plugin_Stop;
 }
 
-public void Event_TeamplayRestartRound(Event event, const char[] name, bool dontBroadcast)
-{
-	/* Game got restarted - reset our round count tracking */
-	g_TotalRounds = 0;	
-}
-
 public void Event_TeamplayWinPanel(Event event, const char[] name, bool dontBroadcast)
 {
 	if (g_ChangeMapAtRoundEnd)
@@ -512,14 +503,13 @@ public void Event_TeamplayWinPanel(Event event, const char[] name, bool dontBroa
 		
 	if (event.GetInt("round_complete") == 1 || StrEqual(name, "arena_win_panel"))
 	{
-		g_TotalRounds++;
 		
 		if (!g_MapList.Length || g_HasVoteStarted || g_MapVoteCompleted || !g_ConVars[mapvote_endvote].BoolValue)
 		{
 			return;
 		}
 		
-		CheckMaxRounds(g_TotalRounds);
+		CheckMaxRounds();
 		
 		switch(event.GetInt("winning_team"))
 		{
@@ -569,8 +559,6 @@ public void Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 	{
 		SetFailState("Mod exceed maximum team count - Please file a bug report.");	
 	}
-
-	g_TotalRounds++;
 	
 	g_winCount[winner]++;
 	
@@ -580,7 +568,7 @@ public void Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 	}
 	
 	CheckWinLimit(g_winCount[winner]);
-	CheckMaxRounds(g_TotalRounds);
+	CheckMaxRounds();
 }
 
 public void CheckWinLimit(int winner_score)
@@ -598,10 +586,11 @@ public void CheckWinLimit(int winner_score)
 	}
 }
 
-public void CheckMaxRounds(int roundcount)
+public void CheckMaxRounds()
 {		
 	if (g_ConVars[mp_maxrounds])
 	{
+		int roundcount = GameRules_GetProp("m_nRoundsPlayed");
 		int maxrounds = g_ConVars[mp_maxrounds].IntValue;
 		if (maxrounds)
 		{

--- a/addons/sourcemod/scripting/nativevotes_votescramble.sp
+++ b/addons/sourcemod/scripting/nativevotes_votescramble.sp
@@ -41,6 +41,7 @@ bool g_NativeVotes;
 bool g_RegisteredScramble = false;
 int g_ScrambleTime = 0;
 float g_MapResetTime = 0;
+int g_SetRoundsPlayedTo = -1;
 
 public void OnPluginStart()
 {
@@ -212,7 +213,14 @@ public void Event_TeamplayRoundStart(Event event, const char[] name, bool dontBr
     if (!g_ConVars[full_reset].BoolValue)
     {
         GameRules_SetPropFloat("m_flMapResetTime", g_MapResetTime);
+
+        // If this isn't -1 we know our plugin just triggered a scramble, gotta change it back
+        if (g_SetRoundsPlayedTo >= 0)
+        {
+            GameRules_SetProp("m_nRoundsPlayed", g_SetRoundsPlayedTo);
+        }
     }
+    g_SetRoundsPlayedTo = -1;
 }
 
 public Action Command_VoteScramble(int client, int args)
@@ -451,9 +459,10 @@ void ScrambleVoteResult(NativeVote vote, int num_votes, int num_clients, const i
         NativeVotes_DisplayPassEx(vote, NativeVotesPass_Scramble);
         CPrintToChatAll(PLUGIN_PREFIX ... " %t", "Scrambling Teams");
 
-        // mp_scrambleteams 2 preserves rounds played for mp_maxrounds.
+        // mp_scrambleteams 2 SHOULD preserve rounds played for mp_maxrounds, but doesn't appear to at the moment.
         ServerCommand(g_ConVars[full_reset].BoolValue ? "mp_scrambleteams" : "mp_scrambleteams 2");
         g_MapResetTime = GameRules_GetPropFloat("m_flMapResetTime");
+        g_SetRoundsPlayedTo = GameRules_GetProp("m_nRoundsPlayed");
     }
     else if (yesVotes == 0 && noVotes == 0)
     {


### PR DESCRIPTION
So `mp_scrambleteams 2` doesn't actually preserve the rounds played (stored in tf_gamerules as `m_nRoundsPlayed`), so had to add some extra code to preserve that when desired.

Also, mapchooser manually tracks the rounds played, which will become unaligned with `m_nRoundsPlayed` if the votescramble plugin preserves it. I refactored mapchooser to read `m_nRoundsPlayed` instead as that is the source of truth.