### PR TITLE
Allow infinite nominations and pick a subset at random

### DIFF
--- a/addons/sourcemod/scripting/nativevotes_mapchooser.sp
+++ b/addons/sourcemod/scripting/nativevotes_mapchooser.sp
@@ -87,9 +87,9 @@ enum
 	mapvote_voteduration,
 	mapvote_runoff,
 	mapvote_runoffpercent,
+	mapvote_shuffle_nominations,
 	mapcycle_auto,
 	mapcycle_exclude,
-	mapvote_shuffle_nominations,
 	workshop_map_collection,
 	workshop_cleanup,
 
@@ -186,9 +186,9 @@ public void OnPluginStart()
 	g_ConVars[mapvote_voteduration]  		= CreateConVar("sm_mapvote_voteduration", "20", "Specifies how long the mapvote should be available for.", _, true, 5.0);
 	g_ConVars[mapvote_runoff] 		 		= CreateConVar("sm_mapvote_runoff", "0", "Hold run of votes if winning choice is less than a certain margin.", _, true, 0.0, true, 1.0);
 	g_ConVars[mapvote_runoffpercent] 		= CreateConVar("sm_mapvote_runoffpercent", "50", "If winning choice has less than this percent of votes, hold a runoff.", _, true, 0.0, true, 100.0);
+	g_ConVars[mapvote_shuffle_nominations]	= CreateConVar("sm_mapvote_shuffle_nominations", "0", "If set, allows infinite nominations and picks a random subset to appear in the vote.", _, true, 0.0, true, 1.0);
 	g_ConVars[mapcycle_auto]         		= CreateConVar("sm_mapcycle_auto", "0", "Specifies whether or not to automatically populate the maps list.", _, true, 0.0, true, 1.0);
 	g_ConVars[mapcycle_exclude]      		= CreateConVar("sm_mapcycle_exclude", ".*test.*|background01|^tr.*$", "Specifies which maps shouldn't be automatically added with a regex pattern.");
-	g_ConVars[mapvote_shuffle_nominations]	= CreateConVar("sm_mapvote_shuffle_nominations", "0", "If set, allows infinite nominations and picks a random subset to appear in the vote.", _, true, 0.0, true, 1.0);
 
 	if (engine != Engine_SDK2013 && engine == Engine_TF2)
 	{
@@ -1433,11 +1433,6 @@ NominateResult InternalNominateMap(char[] map, bool force, int owner)
 	}
 
 	if (!g_ConVars[mapvote_shuffle_nominations].BoolValue && g_NominateList.Length >= maxIncludes && !force)
-	{
-		return Nominate_VoteFull;
-	}
-	
-	if (g_NominateList.Length >= maxIncludes && !force)
 	{
 		return Nominate_VoteFull;
 	}


### PR DESCRIPTION
My server is a 64 slot server, so only letting the first 4-5 people nominate a map sucks for those who join late. I solved this by letting everyone nominate a map, then picking maps from the nominated set at random.

This PR implements this behaviour behind the cvar `sm_mapvote_shuffle_nominations 1`.