### PR TITLE
Fix: Vote HUD stuck on screen (#2) and random translation language (#21)

### DIFF
--- a/addons/sourcemod/scripting/nativevotes_mapchooser.sp
+++ b/addons/sourcemod/scripting/nativevotes_mapchooser.sp
@@ -1149,13 +1149,13 @@ public int Handler_MapVoteMenu(Menu menu, MenuAction action, int param1, int par
 				menu.GetItem(param2, map, sizeof(map));
 				if (strcmp(map, VOTE_EXTEND, false) == 0)
 				{
-					Format(buffer, sizeof(buffer), "%t", "Extend Map", param1);
+					Format(buffer, sizeof(buffer), "%T", "Extend Map", param1);
 					return RedrawMenuItem(buffer);
 				}
 				else if (strcmp(map, VOTE_DONTCHANGE, false) == 0)
 				{
-					Format(buffer, sizeof(buffer), "%t", "Dont Change", param1);
-					return RedrawMenuItem(buffer);					
+					Format(buffer, sizeof(buffer), "%T", "Dont Change", param1);
+					return RedrawMenuItem(buffer);
 				}
 			}
 		}		
@@ -1214,12 +1214,12 @@ public int Handler_NV_MapVoteMenu(NativeVote menu, MenuAction action, int param1
 				menu.GetItem(param2, map, sizeof(map));
 				if (strcmp(map, VOTE_EXTEND, false) == 0)
 				{
-					Format(buffer, sizeof(buffer), "%t", "Extend Map", param1);
+					Format(buffer, sizeof(buffer), "%T", "Extend Map", param1);
 					return view_as<int>(NativeVotes_RedrawVoteItem(buffer));
 				}
 				else if (strcmp(map, VOTE_DONTCHANGE, false) == 0)
 				{
-					Format(buffer, sizeof(buffer), "%t", "Dont Change", param1);
+					Format(buffer, sizeof(buffer), "%T", "Dont Change", param1);
 					return view_as<int>(NativeVotes_RedrawVoteItem(buffer));
 				}
 			}


### PR DESCRIPTION
## Summary

- **Fix vote HUD getting stuck on screen (#2):** NativeVotes' vote index counter started at 0 and counted upward, colliding with the game's internal `s_nVoteIdx`. The client HUD uses the vote index to determine whether a vote is new or stale — duplicate indices cause the HUD to not refresh or dismiss properly. Fixed by initializing `s_nNativeVoteIdx` at `0x7FFFFFFF` and counting downward, ensuring NativeVotes indices never collide with the game's upward counter. Also removed the `m_nVoteIdx = -1` reset in `TF2CSGO_ResetVote()` which could leave stale HUD state.

- **Fix random language for Extend Map / Don't Change options (#21):** The `MenuAction_DisplayItem` handlers in `nativevotes_mapchooser.sp` used `Format()` with `%t`, which translates using `LANG_SERVER` or `SetGlobalTransTarget` instead of the viewing client's language. Changed to `%T` with explicit client index (`param1`) so each player sees vote options in their own language.

## Files Changed

- `addons/sourcemod/scripting/nativevotes/game.sp` — vote index management
- `addons/sourcemod/scripting/nativevotes_mapchooser.sp` — translation format specifiers

## Test Plan

- [ ] Compile `nativevotes.sp` — should produce 0 new warnings
- [ ] Compile `nativevotes_mapchooser.sp` — should produce 0 warnings
- [ ] Start a NativeVotes vote, let it pass/fail — HUD should dismiss cleanly
- [ ] Start multiple consecutive votes — no stuck HUD elements
- [ ] Connect a client with non-English language set — Extend Map / Don't Change should appear in their language
- [ ] Verify built-in engine votes (ESC menu) still work after a NativeVotes vote ends

Closes #2, Closes #21